### PR TITLE
feat: support removing reactions

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -5691,7 +5691,7 @@
     },
     "src/slack": {
       "name": "@modelcontextprotocol/server-slack",
-      "version": "0.6.2",
+      "version": "0.6.3",
       "license": "MIT",
       "dependencies": {
         "@modelcontextprotocol/sdk": "1.0.1"

--- a/src/slack/README.md
+++ b/src/slack/README.md
@@ -34,7 +34,18 @@ MCP Server for the Slack API, enabling Claude to interact with Slack workspaces.
      - `reaction` (string): Emoji name without colons
    - Returns: Reaction confirmation
 
-5. `slack_get_channel_history`
+5. `slack_remove_reaction`
+   - Remove an emoji reaction from a message, file, or file comment
+   - Required inputs:
+     - `reaction` (string): Emoji name without colons
+   - Optional inputs (must provide either file_id, file_comment_id, or both channel_id and timestamp):
+     - `file_id` (string): ID of the file to remove reaction from
+     - `file_comment_id` (string): ID of the file comment to remove reaction from
+     - `channel_id` (string): The channel containing the message
+     - `timestamp` (string): Message timestamp to remove reaction from
+   - Returns: Reaction removal confirmation
+
+6. `slack_get_channel_history`
    - Get recent messages from a channel
    - Required inputs:
      - `channel_id` (string): The channel ID
@@ -45,7 +56,7 @@ MCP Server for the Slack API, enabling Claude to interact with Slack workspaces.
      - `oldest` (string): Only messages after this Unix timestamp (format: 1234567890.123456)
    - Returns: List of messages with their content and metadata
 
-6. `slack_get_thread_replies`
+7. `slack_get_thread_replies`
    - Get all replies in a message thread
    - Required inputs:
      - `channel_id` (string): The channel containing the thread
@@ -53,14 +64,14 @@ MCP Server for the Slack API, enabling Claude to interact with Slack workspaces.
    - Returns: List of replies with their content and metadata
 
 
-7. `slack_get_users`
+8. `slack_get_users`
    - Get list of workspace users with basic profile information
    - Optional inputs:
      - `cursor` (string): Pagination cursor for next page
      - `limit` (number, default: 100, max: 200): Maximum users to return
    - Returns: List of users with their basic profiles
 
-8. `slack_get_user_profile`
+9. `slack_get_user_profile`
    - Get detailed profile information for a specific user
    - Required inputs:
      - `user_id` (string): The user's ID


### PR DESCRIPTION
<!-- Provide a brief description of your changes -->

## Description

Add support for removing reactions via this [API endpoint](https://api.slack.com/methods/reactions.remove)

## Server Details
<!-- If modifying an existing server, provide details -->
- Server: slack
- Changes to: tools

## Motivation and Context
The MCP server can add reactions, it should be able to remove them as well.

## How Has This Been Tested?
Tested with Inspector, see screenshot
![Screenshot 2025-03-27 at 11 57 40 AM](https://github.com/user-attachments/assets/88f1e9ba-aab8-4da9-9ed4-96b3da9c280d)


## Breaking Changes
None

## Types of changes
<!-- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [x] Documentation update

## Checklist
<!-- Go over all the following points, and put an `x` in all the boxes that apply. -->
- [x] I have read the [MCP Protocol Documentation](https://modelcontextprotocol.io)
- [x] My changes follows MCP security best practices
- [x] I have updated the server's README accordingly
- [x] I have tested this with an LLM client
- [x] My code follows the repository's style guidelines
- [x] New and existing tests pass locally
- [x] I have added appropriate error handling
- [x] I have documented all environment variables and configuration options

## Additional context
<!-- Add any other context, implementation notes, or design decisions -->
